### PR TITLE
Updating chatrooms description

### DIFF
--- a/api/Gemfile
+++ b/api/Gemfile
@@ -1,7 +1,7 @@
 source "https://rubygems.org"
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
-ruby "3.1.2"
+ruby "3.2.2"
 
 # Bundle edge Rails instead: gem "rails", github: "rails/rails", branch: "main"
 gem "rails", "~> 7.0.3", ">= 7.0.3.1"
@@ -52,4 +52,3 @@ group :development do
   # Speed up commands on slow machines / big apps [https://github.com/rails/spring]
   # gem "spring"
 end
-

--- a/api/Gemfile.lock
+++ b/api/Gemfile.lock
@@ -121,6 +121,8 @@ GEM
     nio4r (2.5.9)
     nokogiri (1.15.3-arm64-darwin)
       racc (~> 1.4)
+    nokogiri (1.15.3-x64-mingw-ucrt)
+      racc (~> 1.4)
     puma (5.6.6)
       nio4r (~> 2.0)
     racc (1.7.1)
@@ -185,10 +187,13 @@ GEM
       activesupport (>= 5.2)
       sprockets (>= 3.0.0)
     sqlite3 (1.6.3-arm64-darwin)
+    sqlite3 (1.6.3-x64-mingw-ucrt)
     thor (1.2.2)
     timeout (0.4.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
+    tzinfo-data (1.2023.3)
+      tzinfo (>= 1.0.0)
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
@@ -196,6 +201,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-21
+  x64-mingw-ucrt
 
 DEPENDENCIES
   bootsnap
@@ -213,7 +219,7 @@ DEPENDENCIES
   tzinfo-data
 
 RUBY VERSION
-   ruby 3.1.2p20
+   ruby 3.2.2p53
 
 BUNDLED WITH
    2.4.12

--- a/console/src/modules/chatroom/ChatroomListItem.tsx
+++ b/console/src/modules/chatroom/ChatroomListItem.tsx
@@ -1,4 +1,4 @@
-import { KeyboardArrowDown, KeyboardArrowUp } from "@mui/icons-material";
+import { KeyboardArrowDown, KeyboardArrowUp, Edit, Save, Cancel } from "@mui/icons-material";
 import {
   Box,
   Card,
@@ -7,6 +7,7 @@ import {
   IconButton,
   Typography,
   styled,
+  Input,
 } from "@mui/material";
 import { useState } from "react";
 
@@ -28,8 +29,19 @@ export const ChatroomListItem: React.FC<ChatroomListItemProps> = ({
   chatroom,
 }) => {
   const [showDetails, setShowDetails] = useState(false);
+  const [isEditing, setIsEditing] = useState(false);
+  const [editedDescription, setEditedDescription] = useState(chatroom.description);
 
   const natureCodeName = chatroom.natureCode?.name ?? "Uncategorized";
+
+  const handleEditClick = () => {
+    setIsEditing(true);
+  };
+
+  const handleCancelClick = () => {
+    setIsEditing(false);
+    setEditedDescription(chatroom.description);
+  };
 
   return (
     <ChatroomCard variant="outlined">


### PR DESCRIPTION
Part 1
- Add an "Edit" button to chatroom list item descriptions
- Clicking the "Edit" button should make the description editable and add two buttons: (1) cancel, and (2) save
- If saved, the chatroom's description should be updated

Part 2
- Add a "Resolve" button to chatroom list items
- Clicking on the "Resolve" button should prompt the user to confirm they want to resolve the chatroom
- If confirmed, the chatroom's archived field should be updated to true and should be removed from the chatrooms page